### PR TITLE
fix swig wrappers for pyqobject()

### DIFF
--- a/include/inspector/qtgui_inspector_sink_vf.h
+++ b/include/inspector/qtgui_inspector_sink_vf.h
@@ -24,7 +24,7 @@
 
 #ifdef ENABLE_PYTHON
   #include <Python.h>
-#else
+#endif
 
 #include <inspector/api.h>
 #include <gnuradio/sync_block.h>

--- a/lib/qtgui_inspector_sink_vf_impl.h
+++ b/lib/qtgui_inspector_sink_vf_impl.h
@@ -36,11 +36,11 @@ namespace gr {
       qtgui_inspector_sink_vf_impl(int fft_len, QWidget *parent);
       ~qtgui_inspector_sink_vf_impl();
 
-//#ifdef ENABLE_PYTHON
+#ifdef ENABLE_PYTHON
       PyObject* pyqwidget();
-//#else
+#else
       void* pyqwidget();
-//#endif
+#endif
 
       int d_argc;
       char *d_argv;

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -35,6 +35,8 @@ if(NOT SWIG_FOUND OR NOT PYTHONLIBS_FOUND)
 endif()
 include(GrSwig)
 include(GrPython)
+add_definitions(-DENABLE_PYTHON)
+list(APPEND GR_SWIG_FLAGS "-DENABLE_PYTHON")
 
 ########################################################################
 # Setup swig generation


### PR DESCRIPTION
as I suspected, the problem was the conditionalizing of Python support. You forgot to add that to the swig stuff - so it was generating wrappers for the "wrong headers"

(also fixed some minor errors)
