### PR TITLE
Add logging functionality to signal detector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake/Modules)
 # Set the version information here
 set(VERSION_INFO_MAJOR_VERSION 1)
 set(VERSION_INFO_API_COMPAT    1)
-set(VERSION_INFO_MINOR_VERSION 1)
+set(VERSION_INFO_MINOR_VERSION 2)
 set(VERSION_INFO_MAINT_VERSION git)
 
 # Set cmake policies.

--- a/examples/signal_detection.grc
+++ b/examples/signal_detection.grc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<?grc format='1' created='3.7.11'?>
+<?grc format='1' created='3.8.git'?>
 <flow_graph>
   <timestamp>Wed May  4 16:44:48 2016</timestamp>
   <block>
@@ -482,7 +482,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(816, 264)</value>
+      <value>(1048, 144)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -682,7 +682,7 @@
     <key>inspector_signal_detector_cvf</key>
     <param>
       <key>auto</key>
-      <value>True</value>
+      <value>False</value>
     </param>
     <param>
       <key>avg</key>
@@ -710,7 +710,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(592, 516)</value>
+      <value>(560, 88)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -719,6 +719,10 @@
     <param>
       <key>id</key>
       <value>inspector_signal_detector_cvf_0</value>
+    </param>
+    <param>
+      <key>logfile</key>
+      <value></value>
     </param>
     <param>
       <key>maxoutbuf</key>
@@ -734,7 +738,7 @@
     </param>
     <param>
       <key>quant</key>
-      <value>0.001</value>
+      <value>0.0001</value>
     </param>
     <param>
       <key>samp_rate</key>
@@ -746,7 +750,7 @@
     </param>
     <param>
       <key>threshold</key>
-      <value>-10</value>
+      <value>-20</value>
     </param>
     <param>
       <key>window</key>

--- a/grc/inspector_signal_detector_cvf.xml
+++ b/grc/inspector_signal_detector_cvf.xml
@@ -4,7 +4,7 @@
   <category>[Inspector]/Conditioning</category>
   <import>import inspector</import>
   <make>inspector.signal_detector_cvf($samp_rate, $fft_len, $window,
-    $threshold, $sensitivity, $auto, $avg, $quant, $min_bw)</make>
+    $threshold, $sensitivity, $auto, $avg, $quant, $min_bw, $logfile)</make>
   <callback>set_fft_len($fft_len)</callback>
   <callback>set_window_type($window)</callback>
   <callback>set_samp_rate($samp_rate)</callback>
@@ -104,6 +104,13 @@
     <key>min_bw</key>
     <value>0</value>
     <type>real</type>
+    <hide>part</hide>
+  </param>
+  <param>
+    <name>Logfile</name>
+    <key>logfile</key>
+    <value></value>
+    <type>file_save</type>
     <hide>part</hide>
   </param>
   <sink>

--- a/include/inspector/signal_detector_cvf.h
+++ b/include/inspector/signal_detector_cvf.h
@@ -79,11 +79,13 @@ namespace gr {
        * \param average Averaging factor in (0,1] (equal to alpha in IIR equation)
        * \param quantization Bandwidth quantization yields quantization*samp_rate [Hz]
        * \param min_bw Minimum signal bandwidth. Don't pass any narrower signals.
+       * \param filename Path to a file where the detections are logged. Leave empty for no log.
        */
       static sptr make(double samp_rate, int fft_len = 1024, int window_type = 0,
                        float threshold = 0.7, float sensitivity = 0.2,
                        bool auto_threshold = true, float average = 0.8,
-                       float quantization = 0.01, float min_bw = 0.0);
+                       float quantization = 0.01, float min_bw = 0.0,
+                       const char *filename = "");
 
       virtual void set_samp_rate(double d_samp_rate) = 0;
       virtual void set_fft_len(int fft_len) = 0;

--- a/lib/signal_detector_cvf_impl.h
+++ b/lib/signal_detector_cvf_impl.h
@@ -27,6 +27,7 @@
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/filter/single_pole_iir.h>
+#include <fstream>
 
 namespace gr {
   namespace inspector {
@@ -39,6 +40,7 @@ namespace gr {
       float d_threshold, d_sensitivity, d_average, d_quantization, d_min_bw;
       float *d_pxx, *d_tmp_pxx, *d_pxx_out, *d_tmpbuf;
       double d_samp_rate;
+      std::ofstream logfile;
 
       std::vector<filter::single_pole_iir<float,float,double> > d_avg_filter;
       filter::firdes::win_type d_window_type;
@@ -46,13 +48,17 @@ namespace gr {
       std::vector<std::vector<float> > d_signal_edges;
       fft::fft_complex *d_fft;
       std::vector<float> d_freq;
+      const char* d_filename;
+
+      void write_logfile_header();
+      void write_logfile_entry();
 
     public:
       signal_detector_cvf_impl(double samp_rate, int fft_len,
                               int window_type, float threshold,
                               float sensitivity, bool auto_threshold,
                               float average, float quantization,
-                              float min_bw);
+                              float min_bw, const char *filename);
 
       ~signal_detector_cvf_impl();
 


### PR DESCRIPTION
Signal detector can now (even without GUI) write all detections to a log file.
