### PR TITLE
Pull req. for TensorFlow 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To install the Inspector, the following dependencies are required:
 - QT4
 - QWT 6.1.0
 - QwtPlot3D
-- TensorFlow 0.10 ([pip installation](https://www.tensorflow.org/versions/r0.10/get_started/os_setup.html#pip-installation) - you need the version for Python 2.7)
+- TensorFlow 0.12 ([pip installation](https://www.tensorflow.org/get_started/os_setup#pip_installation) - you need the version for Python 2.7)
 
 Install by the following shell commands:
 

--- a/docs/doxygen/other/main_page.dox
+++ b/docs/doxygen/other/main_page.dox
@@ -20,7 +20,7 @@ To install the Inspector, the following dependencies are required:
 - QT4
 - QWT 6.1.0
 - QwtPlot3D
-- TensorFlow 0.10 ([pip installation](https://www.tensorflow.org/versions/r0.10/get_started/os_setup.html#pip-installation) - you need the version for Python 2.7)
+- TensorFlow 0.12 ([pip installation](https://www.tensorflow.org/get_started/os_setup#pip_installation) - you need the version for Python 2.7)
 
 Install by the following shell commands:
 
@@ -36,7 +36,7 @@ sudo make install</code>
 
 You can obtain the code to generate AMC models [here](https://github.com/chrisruk/models).
 
-It is necessary to first install TensorFlow version 0.10+, which you can do easily through the TensorFlow [pip install](https://www.tensorflow.org/versions/r0.10/get_started/os_setup.html#pip-installation).
+It is necessary to first install TensorFlow version 0.12+, which you can do easily through the TensorFlow [pip install](https://www.tensorflow.org/get_started/os_setup#pip_installation).
 
 It is also necessary to install our fork of gr-specest from [here](https://github.com/chrisruk/gr-specest).
 

--- a/python/tfmodel_vcf.py
+++ b/python/tfmodel_vcf.py
@@ -76,7 +76,7 @@ class tfmodel_vcf(gr.sync_block):
     ## \param output_graph_path Path of graph file
     def load_graph(self, output_graph_path):
 
-        sess, meta_graph_def = session_bundle.LoadSessionBundleFromPath(
+        sess, meta_graph_def = session_bundle.load_session_bundle_from_path(
             output_graph_path)
 
         with sess.as_default():


### PR DESCRIPTION
Sorry this took so long.  It seems to use TF 0.12 I couldn't seem to use my previous version model, but when they where re-generated it worked fine.

I've changed the docs to say use 0.12+