### PR TITLE
Fixed threading issue where resizing would crash 

### DIFF
--- a/lib/inspector_form.h
+++ b/lib/inspector_form.h
@@ -107,6 +107,7 @@ namespace gr {
         RIGHT
       };
 
+      bool change_flag;
       int d_interval, d_fft_len, d_marker_count;
       int *d_rf_unit;
       bool *d_manual;


### PR DESCRIPTION
Fixed threading issue where resizing would crash due to due removal of markers during plot.  Existing mutex isn't sufficient because on resize Qt generates it's own call to Qwt and so calls plot outside mutex but on the main thread.  This changes the msg_received paradigm so now it leaves a flag for the main thread to handle the calls when the next refresh happens.