### PR TITLE
added execution of ldconfig in readme-installing instrcutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center">
+﻿<div align="center">
 
 <img src="https://github.com/gnuradio/gr-inspector/blob/master/docs/doxygen/images/logo_body_big.png" />
 
@@ -37,6 +37,7 @@ cd build
 cmake ..
 make -j4
 sudo make install
+sudo ldconfig
 ```
 
 ## Usage


### PR DESCRIPTION
added execution of ldconfig in installing instructions, which solves #14 for people that aren't using pybombs.

This solved the issue for me, since I built gnuradio from sources.