### PR TITLE
Restore Buildability on main, warn about broken block

### DIFF
--- a/lib/ofdm_bouzegzi_c_impl.h
+++ b/lib/ofdm_bouzegzi_c_impl.h
@@ -38,7 +38,6 @@ public:
 
 private:
     int d_Nb;
-    unsigned int d_len = DEFAULT_LEN;
     volk::vector<float> d_x1;
     volk::vector<float> d_y1;
     volk::vector<float> d_x2;
@@ -55,7 +54,6 @@ private:
     void rescale_fft(unsigned int length);
 
     float autocorr(const gr_complex* sig, int a, int b, int p, unsigned int length);
-    gr_complex autocorr_orig(const gr_complex* sig, int a, int b, int p);
     float cost_func(const gr_complex* sig, int a, int b, unsigned int length);
 
 public:

--- a/lib/ofdm_synchronizer_cc_impl.h
+++ b/lib/ofdm_synchronizer_cc_impl.h
@@ -30,7 +30,8 @@ namespace inspector {
 class ofdm_synchronizer_cc_impl : public ofdm_synchronizer_cc
 {
 private:
-    int d_fft_len, d_cp_len, d_tag_pos, d_min_items;
+    unsigned int d_fft_len, d_cp_len, d_min_items;
+    std::optional<std::uint64_t> d_tag_pos;
     bool d_msg_received;
     blocks::rotator d_rotator;
     gr::thread::mutex d_mutex;

--- a/lib/ofdm_zkf_c_impl.h
+++ b/lib/ofdm_zkf_c_impl.h
@@ -33,9 +33,7 @@ private:
     double d_samp_rate;
     unsigned int d_signal;
     std::vector<int> d_typ_len, d_typ_cp;
-    gr_complex* d_Rxx;
     fft::fft_complex_fwd* d_fft;
-    unsigned int d_tmpbuflen;
     int d_min_items;
 
 public:

--- a/lib/signal_detector_cvf_impl.h
+++ b/lib/signal_detector_cvf_impl.h
@@ -21,12 +21,13 @@
 #ifndef INCLUDED_INSPECTOR_SIGNAL_DETECTOR_CVF_IMPL_H
 #define INCLUDED_INSPECTOR_SIGNAL_DETECTOR_CVF_IMPL_H
 
-#include <gnuradio/fft/window.h>
 #include <gnuradio/fft/fft.h>
+#include <gnuradio/fft/window.h>
 #include <gnuradio/filter/firdes.h>
 #include <gnuradio/filter/single_pole_iir.h>
 #include <gnuradio/inspector/signal_detector_cvf.h>
 #include <fstream>
+#include <memory>
 
 namespace gr {
 namespace inspector {
@@ -35,10 +36,13 @@ class signal_detector_cvf_impl : public signal_detector_cvf
 {
 private:
     bool d_auto_threshold;
-    int d_fft_len;
+    unsigned int d_fft_len;
     unsigned int d_tmpbuflen;
     float d_threshold, d_sensitivity, d_average, d_quantization, d_min_bw;
-    float *d_pxx, *d_tmp_pxx, *d_pxx_out, *d_tmpbuf;
+    std::vector<float> d_tmpbuf;
+    std::vector<float> d_pxx;
+    std::vector<float> d_tmp_pxx;
+    std::vector<float> d_pxx_out;
     double d_samp_rate;
     std::ofstream logfile;
 
@@ -46,9 +50,9 @@ private:
     fft::window::win_type d_window_type;
     std::vector<float> d_window;
     std::vector<std::vector<float>> d_signal_edges;
-    fft::fft_complex_fwd* d_fft;
+    std::unique_ptr<fft::fft_complex_fwd> d_fft;
     std::vector<float> d_freq;
-    const char* d_filename;
+    std::string d_filename;
 
     void write_logfile_header();
     void write_logfile_entry();

--- a/lib/signal_extractor_c_impl.cc
+++ b/lib/signal_extractor_c_impl.cc
@@ -50,10 +50,8 @@ signal_extractor_c_impl::signal_extractor_c_impl(int signal,
                      gr::io_signature::make(1, 1, sizeof(gr_complex)))
 {
     message_port_register_in(pmt::intern("sig_in"));
-    set_msg_handler(pmt::intern("sig_in"), [this](pmt::pmt_t msg)
-                    {
-                        this->handle_msg(msg);
-                    });
+    set_msg_handler(pmt::intern("sig_in"),
+                    [this](pmt::pmt_t msg) { this->handle_msg(msg); });
 
 
     d_signal = signal;
@@ -62,7 +60,8 @@ signal_extractor_c_impl::signal_extractor_c_impl(int signal,
     d_out_rate = rate;
     d_rate = 1;
     d_resample = resample;
-    std::vector<float> taps = filter::firdes::low_pass(64, 1000, 1000.0 / 64.0, 100 / 64);
+    std::vector<float> taps =
+        filter::firdes::low_pass(64, 1000, 1000.0 / 64.0, 100. / 64);
     d_resampler = new filter::kernel::pfb_arb_resampler_ccf(d_rate, taps, 64);
 }
 
@@ -102,7 +101,7 @@ int signal_extractor_c_impl::work(int noutput_items,
     // if no samples received, skip work
     if (d_samples.size() > 0) {
         int nout;
-        int item_count = noutput_items;
+        unsigned int item_count = noutput_items;
         // resampling
         if (d_resample) {
             item_count *= 1 / d_rate;


### PR DESCRIPTION
Fixes #49 

__GR_VLA was removed, and should have been volk/std::vector usage to begin with. So, we fix that.

Since we're now handling former VLAs as vectors, we mix destructors, volk_free and free. That is annoying, and rich in, partially very correct, warnings.

So, convert most malloc'ed things to vectors, manually managed ffts to unique_ptr.

Also, there was API misuse in fft_complex_fwd; it's fft_complex_fwd(length, threads), not fft_complex_fwd(length, direction). Luckily, nothing used any direction but forward.
