### PR TITLE
Bouzegzi: don't include unused spdlog/fmt/ranges.h

### DIFF
--- a/lib/ofdm_bouzegzi_c_impl.cc
+++ b/lib/ofdm_bouzegzi_c_impl.cc
@@ -26,7 +26,6 @@
 #include <gnuradio/gr_complex.h>
 #include <gnuradio/io_signature.h>
 #include <gnuradio/logger.h>
-#include <spdlog/fmt/ranges.h>
 #include <volk/volk.h>
 #include <volk/volk_alloc.hh>
 #include <complex>


### PR DESCRIPTION
this was unnecessary and broke build on Ubuntu 22.04

reported by alphafox02 in https://github.com/gnuradio/gr-inspector/issues/55

Signed-off-by: Marcus Müller <marcus@hostalia.de>
