### PR TITLE
Updates from radioconda build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# In GNU Radio 3.9+, pybind11 compares hash values of headers and source
+# files against knowns values.  Conversion of values to CRLF on checkout
+# break those checks so keep LF values when files are subject to said checks
+#
+*.h    text eol=lf
+*.c    text eol=lf
+*.cc   text eol=lf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ add_custom_target(uninstall
 add_subdirectory(include/gnuradio/inspector)
 add_subdirectory(lib)
 add_subdirectory(apps)
+add_subdirectory(examples)
 add_subdirectory(docs)
 # NOTE: manually update below to use GRC to generate C++ flowgraphs w/o python
 if(ENABLE_PYTHON)
@@ -160,3 +161,6 @@ configure_package_config_file(
     INSTALL_DESTINATION ${GR_CMAKE_DIR}
 )
 
+install(FILES MANIFEST.yml
+    RENAME MANIFEST-${VERSION_MAJOR}.${VERSION_API}.${VERSION_ABI}${VERSION_PATCH}.yml
+    DESTINATION share/gnuradio/manifests/inspector)

--- a/MANIFEST.yml
+++ b/MANIFEST.yml
@@ -1,0 +1,32 @@
+title: The INSPECTOR OOT Module
+version: 1.0
+brief: A signal analysis toolbox for GNU Radio
+tags: # Tags are arbitrary, but look at CGRAN what other authors are using
+  - SDR
+  - Signal Analysis
+  - Spectrum Analysis
+  - Signal Intelligence
+  - OFDM
+author:
+  - Sebastian Müller <gsenpo@gmail.com>
+copyright_owner:
+  - Sebastian Müller
+license: GPL-3.0-or-later
+gr_supported_version:
+  - 3.7
+  - 3.8
+  - 3.9
+  - 3.10
+repo: https://github.com/gnuradio/gr-inspector
+website: https://grinspector.wordpress.com/
+icon: https://raw.githubusercontent.com/gnuradio/gr-inspector/master/docs/doxygen/images/logo_body_big.png
+description: |-
+  This toolbox provides algorithms, blocks and tools for signal analysis and
+  spectrum monitoring. Detailed functionality includes signal detection and
+  signal filtering/mixing/decimating/resampling. Further, it is possible
+  to estimate OFDM signal parameters and synchronize to a given OFDM signal.
+
+  This project was initiated as a Google Summer of Code project and developed in
+  cooperation with the *Communication Engineering Lab (CEL)* at the *Karlsruhe
+  Institute of Technology (KIT)*, Germany, <http://www.cel.kit.edu>.
+file_format: 1

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,8 @@
+install(FILES live_fm_demod.grc
+              live_signal_detection.grc
+              ofdm_estimation.grc
+              ofdm_sync.grc
+              recorder.grc
+              signal_detection.grc
+              signal_separation.grc
+    DESTINATION share/gnuradio/examples/inspector)

--- a/lib/ofdm_bouzegzi_c_impl.cc
+++ b/lib/ofdm_bouzegzi_c_impl.cc
@@ -189,7 +189,7 @@ int ofdm_bouzegzi_c_impl::work(int noutput_items,
     if (noutput_items < static_cast<int>(MIN_NOUTPUT_ITEMS)) {
         return 0;
     }
-#warning This block has consistency issues. See the FIXME 2024-06-30 comment above. DO NOT USE IN PRODUCTION.
+#pragma message( "warning: This block has consistency issues. See the FIXME 2024-06-30 comment above. DO NOT USE IN PRODUCTION." )
 
     // Do <+signal processing+>
     float J = 0.0;


### PR DESCRIPTION
1. Add `MANIFEST.yml` with new format
2. Install examples so they are discoverable by GRC-Qt examples browser
3. Ensure that checkouts on Windows use consistent line endings so pybind header hash is consistent
4. Fix build with MSVC due to non-portable `#warning`